### PR TITLE
Fix decoding of VobSub for different RLE offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 /.build/
 /.swiftpm/
 /.vscode/
-tests/images
-tests/*.json
-tests/*.srt
+Tests/Resources/testFiles/*
+Tests/Resources/testFiles/test.*

--- a/Sources/Subtitles/Subtitle.swift
+++ b/Sources/Subtitles/Subtitle.swift
@@ -22,10 +22,13 @@ class Subtitle {
     var imageAlpha: [UInt8]?
     var numberOfColors: Int?
     var endTimestamp: TimeInterval?
+    var evenOffset: Int?
+    var oddOffset: Int?
 
     init(index: Int? = nil, text: String? = nil, startTimestamp: TimeInterval? = nil, endTimestamp: TimeInterval? = nil,
          imageXOffset: Int? = nil, imageYOffset: Int? = nil, imageWidth: Int? = nil, imageHeight: Int? = nil,
-         imageData: Data? = nil, imagePalette: [UInt8]? = nil, imageAlpha: [UInt8]? = nil, numberOfColors: Int? = nil) {
+         imageData: Data? = nil, imagePalette: [UInt8]? = nil, imageAlpha: [UInt8]? = nil, numberOfColors: Int? = nil,
+         evenOffset: Int? = nil, oddOffset: Int? = nil) {
         self.index = index
         self.text = text
         self.startTimestamp = startTimestamp
@@ -38,6 +41,8 @@ class Subtitle {
         self.imagePalette = imagePalette
         self.imageAlpha = imageAlpha
         self.numberOfColors = numberOfColors
+        self.evenOffset = evenOffset
+        self.oddOffset = oddOffset
     }
 
     // MARK: - Functions
@@ -75,6 +80,7 @@ class Subtitle {
     // Converts the image data to RGBA format using the palette
     private func imageDataToRGBA() -> Data {
         let bytesPerPixel = 4
+        imageHeight = imageData!.count / imageWidth!
         var rgbaData = Data(capacity: imageWidth! * imageHeight! * bytesPerPixel)
 
         for y in 0 ..< imageHeight! {

--- a/Sources/Subtitles/VobSub/VobSubParser.swift
+++ b/Sources/Subtitles/VobSub/VobSubParser.swift
@@ -181,6 +181,12 @@ struct VobSubParser {
                     .imageYOffset! + 1
                 index += 3
                 logger.debug("Image size: \(subtitle.imageWidth!)x\(subtitle.imageHeight!)")
+                logger.debug("X Offset: \(subtitle.imageXOffset!), Y Offset: \(subtitle.imageYOffset!)")
+            case 6:
+                subtitle.evenOffset = Int(controlHeader.value(ofType: UInt16.self, at: index)! - 4)
+                subtitle.oddOffset = Int(controlHeader.value(ofType: UInt16.self, at: index + 2)! - 4)
+                index += 4
+                logger.debug("Even offset: \(subtitle.evenOffset!), Odd offset: \(subtitle.oddOffset!)")
             default:
                 break
             }
@@ -202,10 +208,11 @@ struct VobSubParser {
     }
 
     private func decodeImage() {
-        let rleData = RLEData(
+        var rleData = RLEData(
             data: subtitle.imageData ?? Data(),
             width: subtitle.imageWidth ?? 0,
-            height: subtitle.imageHeight ?? 0)
+            height: subtitle.imageHeight ?? 0,
+            evenOffset: subtitle.evenOffset ?? 0)
         subtitle.imageData = rleData.decodeVobSub()
     }
 }


### PR DESCRIPTION
This should fix any issues that could occur due to the data being offset from the typical 0 in the RLE buffer. However this has not been tested against a large number of subtitles, so there may be some cases where it either breaks decoding or doesn't properly interact with various RLE offsets.

Fixes #19